### PR TITLE
Missing dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,18 +29,17 @@
   "homepage": "https://github.com/echenley/chai-equal-jsx#readme",
   "devDependencies": {
     "babel-core": "^6.1.2",
+    "babel-eslint": "^4.1.4",
     "babel-preset-es2015": "^6.1.2",
     "babel-preset-react": "^6.1.2",
-    "babel-eslint": "^4.1.4",
+    "babel-preset-stage-1": "^6.5.0",
     "eslint": "^1.9.0",
     "eslint-plugin-react": "^3.8.0",
     "mocha": "^2.3.3",
     "react": "^0.14.2"
   },
   "dependencies": {
+    "chai": "^3.4.1",
     "react-element-to-jsx-string": "^2.1.0"
-  },
-  "peerDependencies": {
-    "chai": "^3.4.1"
   }
 }


### PR DESCRIPTION
I cloned your repository and tried `npm install`, `npm test` with npm-3, but it failed on missing dependencies. It was missing babel-preset-stage-1. Running npm install also reordered the package file and I moved chai from peer to dependencies.
