### PR TITLE
Exact Version For React-Element-To-JSX-String

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "react": "^0.14.2"
   },
   "dependencies": {
-    "react-element-to-jsx-string": "^2.1.0"
+    "react-element-to-jsx-string": "2.1.0"
   },
   "peerDependencies": {
     "chai": "^3.4.1"


### PR DESCRIPTION
allowing major revisions broke my codebase that uses react 0.14.7 ... 

It looks like react-element-to-jsx-string recently removed their dependency on React-Addons-Test-Utils 

https://github.com/algolia/react-element-to-jsx-string/commit/06d258876c6738461761f26aa7a69764055f3c6d